### PR TITLE
Fix typo in example selector

### DIFF
--- a/Fmt.sublime-settings
+++ b/Fmt.sublime-settings
@@ -10,7 +10,7 @@
   Example for Go:
 
     "rules": [
-      {"selector": "scope.go", "cmd": ["goimports"]},
+      {"selector": "source.go", "cmd": ["goimports"]},
     ],
   */
   "rules": [],


### PR DESCRIPTION
This now matches the example given in https://github.com/mitranim/sublime-fmt/blob/master/messages/install.md