### PR TITLE
fix "<0x0d>" (\r) shows in msg panel under Windows

### DIFF
--- a/Fmt.py
+++ b/Fmt.py
@@ -169,7 +169,7 @@ def report(view, msg):
 
     if style == 'panel':
         msg = '[{}] {}'.format(PLUGIN_NAME, msg)
-        ensure_panel(window).run_command('fmt_panel_replace_content', {'text': msg})
+        ensure_panel(window).run_command('fmt_panel_replace_content', {'text': msg.replace('\r\n', '\n')})
         show_panel(window)
         return
 


### PR DESCRIPTION
This PR removes `<0x0d>` (i.e., `\r`) from the error msg's line endings.

![image](https://github.com/mitranim/sublime-fmt/assets/6594915/ad4e3d97-730f-466f-b3c1-4f6945fc7c29)
